### PR TITLE
fix: typo in prompt Fromat -> Format

### DIFF
--- a/backend/agentChain.go
+++ b/backend/agentChain.go
@@ -125,7 +125,7 @@ func startAgentChain(ctx context.Context, outputChan chan<- utils.HttpJsonStream
 
 	temp := 0.0
 	prompt := fmt.Sprintf(`
-    1. Fromat your answer (after AI:) in markdown. 
+    1. Format your answer (after AI:) in markdown. 
     2. You have to use your tools to answer questions. 
     3. You have to provide the sources / links you've used to answer the quesion.
     4. You may use tools more than once.


### PR DESCRIPTION
Small fix of the prompt Fromat -> Format that LLM should handle anyway.